### PR TITLE
Fix timestamp conversion & add to Message31Header

### DIFF
--- a/archive2/types.go
+++ b/archive2/types.go
@@ -180,6 +180,11 @@ func (h *Message31Header) AzimuthResolutionSpacing() float64 {
 	return 1
 }
 
+// Date returns a time type representing the collection time of the scan.
+func (h *Message31Header) Date() time.Time {
+	return timeFromModifiedJulian(int(h.ModifiedJulianDate), int(h.CollectionTime))
+}
+
 // DataBlock wraps Data Block information
 type DataBlock struct {
 	DataBlockType [1]byte

--- a/archive2/types.go
+++ b/archive2/types.go
@@ -61,7 +61,7 @@ func (vh VolumeHeaderRecord) FileName() string {
 
 func timeFromModifiedJulian(days, ms int) time.Time {
 	return time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).
-		AddDate(0, 0, int(days)).
+		AddDate(0, 0, int(days-1)).
 		Add(time.Duration(ms) * time.Millisecond)
 }
 


### PR DESCRIPTION
This fixes the conversion from modified julian date to provide the correct value.
You could change the epoch date instead, but subtracting `1` is the same method used by the NetCDF library (https://github.com/Unidata/netcdf-java/blob/3ce72c0cd167609ed8c69152bb4a004d1daa9273/cdm/radial/src/main/java/ucar/nc2/iosp/nexrad2/Level2Record.java#L381-L383), so I opted for consistency.

This PR also adds a `Date()` function to `Message31Header` so users don't have to perform calculation manually.

As an example of the fix, here's a Level-II archive as reported by the official NOAA toolkit:
![image](https://user-images.githubusercontent.com/1826947/83447821-0307b680-a41f-11ea-86fc-a20c14673c92.png)

Before change, the time was reported as 2020-06-01 03:02:27.127 +0000 UTC.
After change, the time is reported as 2020-05-31 03:02:27.127 +0000 UTC.

*Also as a nitpick, `Add(time.Hour*24*time.Duration(days) + time.Duration(ms)*time.Millisecond)` would be a lighter method of adding the days. But that's just personal preference, and won't make much difference unless it's called a ton.*