### PR TITLE
pass data instead of &data in m31 reading

### DIFF
--- a/archive2/message31.go
+++ b/archive2/message31.go
@@ -163,7 +163,7 @@ func msg31(r *bytes.Reader) *Message31 {
 			// bits stored for each gate (DWS is always a multiple of 8).
 			ldm := m.NumberDataMomentGates * uint16(m.DataWordSize) / 8
 			data := make([]uint8, ldm)
-			binary.Read(r, binary.BigEndian, &data)
+			binary.Read(r, binary.BigEndian, data)
 
 			d := &DataMoment{
 				GenericDataMoment: m,


### PR DESCRIPTION
Pass the array itself instead of a pointer. This change cuts a sample `./nexrad-render` runtime by ~30% (from 1.25s to 0.85s).